### PR TITLE
Add user interest status to group feed

### DIFF
--- a/src/main/java/com/bbthechange/inviter/dto/HangoutSummaryDTO.java
+++ b/src/main/java/com/bbthechange/inviter/dto/HangoutSummaryDTO.java
@@ -22,6 +22,7 @@ public class HangoutSummaryDTO implements FeedItem {
     private Address location;
     private int participantCount;
     private String mainImagePath; // Denormalized image path from HangoutPointer
+    private String userInterestStatus; // Current user's interest: "GOING", "INTERESTED", "NOT_GOING", or null
     private String type = "hangout"; // Type discriminator for client-side handling
 
     // Additional basic fields
@@ -147,6 +148,14 @@ public class HangoutSummaryDTO implements FeedItem {
 
     public void setMainImagePath(String mainImagePath) {
         this.mainImagePath = mainImagePath;
+    }
+
+    public String getUserInterestStatus() {
+        return userInterestStatus;
+    }
+
+    public void setUserInterestStatus(String userInterestStatus) {
+        this.userInterestStatus = userInterestStatus;
     }
 
     public String getType() {

--- a/src/main/java/com/bbthechange/inviter/repository/HangoutRepository.java
+++ b/src/main/java/com/bbthechange/inviter/repository/HangoutRepository.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Repository interface for hangout/event management operations in the InviterTable.
@@ -179,12 +180,22 @@ public interface HangoutRepository {
     /**
      * Find all hangouts that belong to a specific EventSeries.
      * Uses the SeriesIndex GSI for efficient querying.
-     * 
+     *
      * ⚠️ PERFORMANCE CRITICAL: This method MUST use the SeriesIndex GSI.
      * Never fetch all hangouts and filter in memory - this would be a severe performance issue.
-     * 
+     *
      * @param seriesId The series identifier
      * @return List of hangouts in the series, ordered by start timestamp
      */
     List<Hangout> findHangoutsBySeriesId(String seriesId);
+
+    /**
+     * Batch fetch user's interest level records for multiple hangouts.
+     * Uses BatchGetItem for efficient retrieval of user's interest status across multiple events.
+     *
+     * @param hangoutIds Set of hangout IDs to fetch interest records for
+     * @param userId User ID to get interest status for
+     * @return Map of hangoutId to InterestLevel record (only includes hangouts where user has expressed interest)
+     */
+    Map<String, InterestLevel> batchGetUserInterests(Set<String> hangoutIds, String userId);
 }


### PR DESCRIPTION
Add userInterestStatus field to hangout summaries in group feed to show whether the current user has expressed interest (GOING, INTERESTED, NOT_GOING, or null).

## Changes:
- Add userInterestStatus field to HangoutSummaryDTO
- Add batchGetUserInterests method to HangoutRepository using DynamoDB BatchGetItem
- Add enrichWithUserInterestStatus helper in GroupServiceImpl
- Integrate enrichment into getCurrentAndFutureEvents and getPastEvents

## Performance:
- Single batch query for all hangouts in feed (not N queries)
- O(n) complexity maintained
- Backward compatible (additive change only)

## Testing:
- All related unit tests pass
- No breaking changes to existing API contracts